### PR TITLE
Add Python MP4 index generator

### DIFF
--- a/mp4_indexer.py
+++ b/mp4_indexer.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Scan a directory for MP4 files and generate a JSON index.
+
+输出字段：
+- filename: 文件名
+- size_bytes: 文件大小（字节）
+- duration_seconds: 时长（秒，浮点数）
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def get_duration_seconds(file_path: Path) -> float:
+    """Use ffprobe to get media duration in seconds."""
+    ffprobe = shutil.which("ffprobe")
+    if ffprobe is None:
+        raise RuntimeError("未找到 ffprobe，请先安装 FFmpeg（包含 ffprobe）")
+
+    result = subprocess.run(
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(file_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    output = result.stdout.strip()
+    return float(output)
+
+
+def find_mp4_files(directory: Path, recursive: bool) -> list[Path]:
+    pattern = "**/*.mp4" if recursive else "*.mp4"
+    return sorted(p for p in directory.glob(pattern) if p.is_file())
+
+
+def build_index(directory: Path, recursive: bool) -> list[dict[str, object]]:
+    mp4_files = find_mp4_files(directory, recursive)
+    index: list[dict[str, object]] = []
+
+    for file_path in mp4_files:
+        index.append(
+            {
+                "filename": file_path.name,
+                "size_bytes": file_path.stat().st_size,
+                "duration_seconds": round(get_duration_seconds(file_path), 3),
+            }
+        )
+
+    return index
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="读取目录中的 MP4 并生成 JSON 索引")
+    parser.add_argument("directory", type=Path, help="要扫描的目录")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("mp4_index.json"),
+        help="输出 JSON 文件路径（默认: mp4_index.json）",
+    )
+    parser.add_argument(
+        "-r",
+        "--recursive",
+        action="store_true",
+        help="是否递归扫描子目录",
+    )
+
+    args = parser.parse_args()
+
+    if not args.directory.exists() or not args.directory.is_dir():
+        raise SystemExit(f"目录不存在或不是目录: {args.directory}")
+
+    index_data = build_index(args.directory, args.recursive)
+
+    args.output.write_text(
+        json.dumps(index_data, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    print(f"已生成索引: {args.output}（共 {len(index_data)} 个 mp4 文件）")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- 提供一个命令行工具以扫描目录中的 MP4 文件并生成包含文件名、大小和时长的可机读索引以便后续处理或展示。

### Description
- 新增 `mp4_indexer.py`，会扫描目标目录并输出包含 `filename`、`size_bytes`、`duration_seconds` 的 JSON 数组。
- 使用 `ffprobe`（来自 FFmpeg）获取媒体时长并将结果四舍五入到三位小数，若未找到 `ffprobe` 则抛出错误。
- 支持递归扫描子目录的 `-r/--recursive` 选项以及可配置的输出路径 `-o/--output`。
- 使用 `pathlib` 进行文件发现并对结果进行排序以保证输出顺序确定性。

### Testing
- 已执行 `python3 mp4_indexer.py --help` 并成功显示帮助信息。
- 已执行 `python3 mp4_indexer.py . -o /tmp/mp4_index.json` 并成功生成文件 `/tmp/mp4_index.json`，当时目录中无 `.mp4` 文件因此索引为空列表。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab1e76e648321a80f1d156fb293a1)

## Summary by Sourcery

Add a Python CLI tool to scan directories for MP4 files and generate a JSON index containing file metadata.

New Features:
- Introduce mp4_indexer.py to list MP4 files in a directory and output a JSON index with filename, size in bytes, and duration in seconds.
- Support recursive directory scanning and configurable output path via command-line options.
- Integrate ffprobe-based duration extraction with duration rounded to three decimal places, failing clearly when ffprobe is unavailable.